### PR TITLE
Scorer: fixed printing empty hyps list

### DIFF
--- a/simuleval/scorer/scorer.py
+++ b/simuleval/scorer/scorer.py
@@ -87,7 +87,7 @@ class Scorer(object):
     def gather_translation(self):
         not_finish_write_id = [i for i in range(
             len(self)) if not self.instances[i].finish_hypo]
-        empty_hypo_id = [i for i in range(len(self)) if len(
+        empty_hypo_id = [str(i) for i in range(len(self)) if len(
             self.instances[i].prediction(no_space=self.no_space)) == 0]
 
         if len(not_finish_write_id) > 0:


### PR DESCRIPTION
In case of empty hyps, `print(", ".join(empty_hypo_id), file=sys.stderr)` crashed with TypeError.