### PR TITLE
fix ATD for s2s

### DIFF
--- a/simuleval/evaluator/scorers/latency_scorer.py
+++ b/simuleval/evaluator/scorers/latency_scorer.py
@@ -369,7 +369,7 @@ class ATDScorer(LatencyScorer):
                 chunk_compute_times = []
                 prev_delay = None
                 for delay, compute_time, duration in zip(
-                    delays, compute_times, ins.duration
+                    delays, compute_times, ins.durations
                 ):
                     if delay != prev_delay:
                         chunk_durations.append(duration)

--- a/simuleval/evaluator/scorers/latency_scorer.py
+++ b/simuleval/evaluator/scorers/latency_scorer.py
@@ -380,7 +380,7 @@ class ATDScorer(LatencyScorer):
                     prev_delay = delay
                 for i, chunk_duration in enumerate(chunk_durations, 1):
                     num_tokens, rest = divmod(chunk_duration, TGT_TOKEN_LEN)
-                    token_lens = num_tokens * [TGT_TOKEN_LEN] + (
+                    token_lens = int(num_tokens) * [TGT_TOKEN_LEN] + (
                         [rest] if rest != 0 else []
                     )
                     tgt_token_lens += token_lens


### PR DESCRIPTION
I fixed the name of instance variable of `SpeechToSpeechInstance` in latency score ATD calculation.