### PR TITLE
fixed ATD for s2s

### DIFF
--- a/examples/speech_to_speech/readme.md
+++ b/examples/speech_to_speech/readme.md
@@ -52,15 +52,16 @@ simuleval \
 
 For quality evaluation, we use ASR_BLEU, that is transcribing the speech output and compute BLEU score with the reference text. To use this feature, `fairseq` has to be installed.
 
-We use three metrics for latency evaluation
+We use four metrics for latency evaluation
 
 - `StartOffset`: The starting offset of translation comparing with source audio
 - `EndOffset`: The ending offset of translation comparing with source audio
 - `AL_SpeechAlign_BOW`: compute average lagging (AL) on transcribed text, and use the beginning of the aligned word as the delay to compute AL. This feature requires `mfa`.
+- `ATD`: Average Token Delay
 
 The results of the evaluation should be as following. The transcripts and alignments can be found in the `output` directory.
 
 ```
- ASR_BLEU  StartOffset  EndOffset  AL_SpeechAlign_BOW
-   80.911       1000.0   1490.703             973.565
+ ASR_BLEU  StartOffset  EndOffset  AL_SpeechAlign_BOW      ATD
+   80.911       1000.0   1490.703             973.565 1247.831
 ```

--- a/simuleval/evaluator/scorers/latency_scorer.py
+++ b/simuleval/evaluator/scorers/latency_scorer.py
@@ -380,7 +380,7 @@ class ATDScorer(LatencyScorer):
                 chunk_compute_times = []
                 prev_delay = None
                 for delay, compute_time, duration in zip(
-                    delays, compute_times, ins.duration
+                    delays, compute_times, ins.durations
                 ):
                     if delay != prev_delay:
                         chunk_durations.append(duration)
@@ -391,7 +391,7 @@ class ATDScorer(LatencyScorer):
                     prev_delay = delay
                 for i, chunk_duration in enumerate(chunk_durations, 1):
                     num_tokens, rest = divmod(chunk_duration, TGT_TOKEN_LEN)
-                    token_lens = num_tokens * [TGT_TOKEN_LEN] + (
+                    token_lens = int(num_tokens) * [TGT_TOKEN_LEN] + (
                         [rest] if rest != 0 else []
                     )
                     tgt_token_lens += token_lens


### PR DESCRIPTION
I fixed the bugs of calculating latency score ATD for s2s, and modified readme to add ATD.
I have tried the following command and there was no problems.
`simuleval \
    --agent english_counter_agent.py --output output \
    --source source.txt --target reference/en.txt --source-segment-size 1000\
    --quality-metrics ASR_BLEU \
    --latency-metrics StartOffset EndOffset AL_SpeechAlign_BOW ATD --target-speech-lang en`
I have also tried --computation-aware option and theres were no errors in ATD_CA calculation.
I am glad if you would review my code.
Thank you.