### PR TITLE
fix bug loading sys with nondefault config_name

### DIFF
--- a/simuleval/utils/agent.py
+++ b/simuleval/utils/agent.py
@@ -37,9 +37,10 @@ def get_agent_class(config_dict: Optional[dict] = None) -> GenericAgent:
         EVALUATION_SYSTEM_LIST.append(get_agent_class_from_string(class_name))
 
     system_dir = check_argument("system_dir")
+    config_name = check_argument("system_config")
 
     if system_dir is not None:
-        EVALUATION_SYSTEM_LIST.append(get_agent_class_from_dir(system_dir))
+        EVALUATION_SYSTEM_LIST.append(get_agent_class_from_dir(system_dir, config_name))
 
     agent_file = check_argument("agent")
     if agent_file is not None:
@@ -95,7 +96,7 @@ def build_system_from_dir(
     if overwrite_config_dict is not None:
         for key, value in overwrite_config_dict:
             config_dict[key] = value
-    agent_class = get_agent_class_from_dir(path)
+    agent_class = get_agent_class_from_dir(path, config_name)
 
     parser = options.general_parser()
     agent_class.add_args(parser)


### PR DESCRIPTION
Previous behavior: a non-default config_name is overridden by the default; this fixes the issue