### PR TITLE
Fix the bug end_offset = 0 when running scoring only

### DIFF
--- a/simuleval/evaluator/instance.py
+++ b/simuleval/evaluator/instance.py
@@ -427,6 +427,7 @@ INSTANCE_TYPE_DICT = {
 class LogInstance:
     def __init__(self, info: str) -> None:
         self.info = json.loads(info.strip())
+        self.intervals = []
         for key, value in self.info.items():
             setattr(self, key, value)
 

--- a/simuleval/evaluator/scorers/latency_scorer.py
+++ b/simuleval/evaluator/scorers/latency_scorer.py
@@ -564,7 +564,9 @@ class EndOffsetScorer(LatencyScorer):
 
     def compute(self, ins: Instance):
         delays, source_length, _ = self.get_delays_lengths(ins)
-        if isinstance(ins, SpeechOutputInstance):
+        if isinstance(ins, SpeechOutputInstance) or (
+            isinstance(ins, LogInstance) and len(ins.intervals) > 0
+        ):
             delays = [start + duration for start, duration in ins.intervals]
         return delays[-1] - source_length
 


### PR DESCRIPTION
Previously, running scoring only on speech output will lead to 0 endoffset.

This PR fixed this issue by adding intervals attributes to the LogInstance