### PR TITLE
[Streaming] Enable evaluation of youtube videos

### DIFF
--- a/simuleval/data/dataloader/dataloader.py
+++ b/simuleval/data/dataloader/dataloader.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Union
 from argparse import Namespace, ArgumentParser
 
 SUPPORTED_MEDIUM = ["text", "speech"]
-SUPPORTED_SOURCE_MEDIUM = ["text", "speech"]
+SUPPORTED_SOURCE_MEDIUM = ["youtube", "text", "speech"]
 SUPPORTED_TARGET_MEDIUM = ["text", "speech"]
 DATALOADER_DICT = {}
 

--- a/simuleval/data/dataloader/s2t_dataloader.py
+++ b/simuleval/data/dataloader/s2t_dataloader.py
@@ -10,6 +10,10 @@ from typing import List, Union
 from .dataloader import GenericDataloader
 from simuleval.data.dataloader import register_dataloader
 from argparse import Namespace
+from urllib.parse import urlparse, parse_qs
+import yt_dlp as youtube_dl
+from pydub import AudioSegment
+
 
 try:
     import soundfile
@@ -17,6 +21,38 @@ try:
     IS_IMPORT_SOUNDFILE = True
 except Exception:
     IS_IMPORT_SOUNDFILE = False
+
+
+def download_youtube_video(url):
+    def get_video_id(url):
+        url_data = urlparse(url)
+        query = parse_qs(url_data.query)
+        video = query.get("v", [])
+        if video:
+            return video[0]
+        else:
+            raise Exception("unrecoginzed url format.")
+
+    id = get_video_id(url)
+    name = f"{id}.wav"
+
+    if not Path(name).exists():
+        ydl_opts = {
+            'format': 'bestaudio/best',
+            'postprocessors': [{
+                'key': 'FFmpegExtractAudio',
+                'preferredcodec': 'wav',
+                'preferredquality': '192',
+            }],
+            'outtmpl': id,  # name the file "downloaded_video" with original extension
+        }
+        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
+
+    sound = AudioSegment.from_wav(name)
+    sound = sound.set_channels(1).set_frame_rate(16000)
+    sound.export(name, format="wav")
+    return name
 
 
 @register_dataloader("speech-to-text")
@@ -72,3 +108,30 @@ class SpeechToSpeechDataloader(SpeechToTextDataloader):
         args.source_type = "speech"
         args.target_type = "speech"
         return cls.from_files(args.source, args.target)
+
+
+@register_dataloader("youtube-to-text")
+class YoutubeToTextDataloader(SpeechToTextDataloader):
+    @classmethod
+    def from_youtube(
+        cls, source: Union[Path, str], target: Union[Path, str]
+    ) -> YoutubeToTextDataloader:
+        source_list = [download_youtube_video(source)]
+        target_list = [target]
+        dataloader = cls(source_list, target_list)
+        return dataloader
+
+    @classmethod
+    def from_args(cls, args: Namespace):
+        args.source_type = "youtube"
+        args.target_type = "text"
+        return cls.from_youtube(args.source, args.target)
+
+
+@register_dataloader("youtube-to-speech")
+class YoutubeToSpeechDataloader(YoutubeToTextDataloader):
+    @classmethod
+    def from_args(cls, args: Namespace):
+        args.source_type = "youtube"
+        args.target_type = "speech"
+        return cls.from_youtube(args.source, args.target)

--- a/simuleval/evaluator/evaluator.py
+++ b/simuleval/evaluator/evaluator.py
@@ -209,12 +209,20 @@ class SentenceLevelEvaluator(object):
             metrics.to_csv(self.output / "metrics.tsv", sep="\t", index=False)
 
     def __call__(self, system):
+        system.reset()
         for instance in self.instance_iterator:
-            system.reset()
-            while not instance.finish_prediction:
+            while not instance.source_finished_reading:
                 input_segment = instance.send_source(self.source_segment_size)
                 output_segment = system.pushpop(input_segment)
                 instance.receive_prediction(output_segment)
+                if instance.finish_prediction:
+                    # if instance.finish_prediction where set by the reader,
+                    # source_finished_reading will be set as well. If it is 
+                    # set by any of the intermediate components, then we didn't
+                    # end yet. We are going to clear the state and continue 
+                    # processing the rest of the input.
+                    system.reset()
+
             if not self.score_only:
                 self.write_log(instance)
 

--- a/simuleval/evaluator/instance.py
+++ b/simuleval/evaluator/instance.py
@@ -237,6 +237,7 @@ class SpeechInputInstance(Instance):
         super().__init__(index, dataloader, args)
         self.sample_rate_value = None
         self.sample_list = None
+        self.source_finished_reading = False
         self.dataloader: SpeechToTextDataloader
 
     @property
@@ -269,6 +270,7 @@ class SpeechInputInstance(Instance):
                 # are more than available samples.
                 samples = self.samples[self.step :]  # noqa E203
                 is_finished = True
+                self.source_finished_reading = True
             else:
                 samples = self.samples[self.step : self.step + num_samples]  # noqa E203
                 is_finished = False
@@ -288,6 +290,7 @@ class SpeechInputInstance(Instance):
                 index=self.len_sample_to_ms(self.step),
                 finished=True,
             )
+            self.source_finished_reading = True
 
         return segment
 
@@ -386,7 +389,7 @@ class SpeechOutputInstance(Instance):
         if self.start_time is None:
             self.start_time = time.time()
 
-        if self.finish_prediction:
+        if self.finish_prediction and self.source_finished_reading:
             return
 
         self.finish_prediction = segment.finished
@@ -429,6 +432,8 @@ INSTANCE_TYPE_DICT = {
     "speech-text": SpeechToTextInstance,
     "text-text": TextToTextInstance,
     "speech-speech": SpeechToSpeechInstance,
+    "youtube-text": SpeechToTextInstance,
+    "youtube-speech": SpeechToSpeechInstance,
 }
 
 


### PR DESCRIPTION
Our testing primarily involves short use-cases, and utilizing a demo for testing purposes is time-consuming. This is due to the need for setting up the demo, addressing any existing bugs in the work-in-progress demo, and being limited to running only a single instance at a time and the need to watch the whole video to see the results. In order to expedite and parallelize our experimentation with real-world examples, I am developing this YouTube evaluation tool. The tool take a youtube url and use it for the evaluation.