### PR TITLE
support user-dir and multiple entrypoint by specifying agent-class

### DIFF
--- a/docs/user_guide/agent.rst
+++ b/docs/user_guide/agent.rst
@@ -110,7 +110,9 @@ SimulEval introduces the agent pipeline to support this function.
 The following is a minimal example.
 We concatenate two wait-k systems with different rates (:code:`k=2` and :code:`k=3`)
 Note that if there are more than one agent class define,
-the :code:`@entrypoint` decorator has to be used to determine the entry point
+the :code:`@entrypoint` decorator has to be used to determine the entry point,
+or `--user-dir` and `--agent-class` must be specified. See `simuleval/test/first_agent.py`
+for an example.
 
 .. literalinclude:: ../../examples/quick_start/agent_pipeline.py
    :language: python

--- a/simuleval/options.py
+++ b/simuleval/options.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+import importlib
+import sys
 import logging
 import argparse
 from typing import List, Optional
@@ -109,8 +112,26 @@ def add_scorer_args(
         get_scorer_class("quality", metric).add_args(parser)
 
 
+def import_user_module(module_path):
+    module_path = os.path.abspath(module_path)
+    module_parent, module_name = os.path.split(module_path)
+
+    sys.path.insert(0, module_parent)
+    importlib.import_module(module_name)
+    sys.path.pop(0)
+
+
 def general_parser():
     parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--user-dir",
+        default=None,
+        help="path to a python module containing custom agents"
+    )
+    args, _ = parser.parse_known_args()
+    if args.user_dir is not None:
+        import_user_module(args.user_dir)
     parser.add_argument(
         "--remote-eval",
         action="store_true",

--- a/simuleval/test/test_agent.py
+++ b/simuleval/test/test_agent.py
@@ -19,8 +19,10 @@ ROOT_PATH = Path(__file__).parents[2]
 def test_agent(root_path=ROOT_PATH):
     with tempfile.TemporaryDirectory() as tmpdirname:
         cli.sys.argv[1:] = [
-            "--agent",
-            os.path.join(root_path, "examples", "quick_start", "first_agent.py"),
+            "--user-dir", 
+            os.path.join(root_path, "examples"),
+            "--agent-class",
+            "examples.quick_start.first_agent.DummyWaitkTextAgent",
             "--source",
             os.path.join(root_path, "examples", "quick_start", "source.txt"),
             "--target",

--- a/simuleval/test/test_agent_pipeline.py
+++ b/simuleval/test/test_agent_pipeline.py
@@ -16,9 +16,13 @@ ROOT_PATH = Path(__file__).parents[2]
 
 
 def test_pipeline_cmd(root_path=ROOT_PATH):
+    # NOTE: When importing --agent we use import_file, thus need to specify 
+    # --agent-class as agents.DummyPipeline
     cli.sys.argv[1:] = [
         "--agent",
         os.path.join(root_path, "examples", "quick_start", "agent_pipeline.py"),
+        "--agent-class",
+        "agents.DummyPipeline",
         "--source",
         os.path.join(root_path, "examples", "quick_start", "source.txt"),
         "--target",

--- a/simuleval/test/test_evaluator.py
+++ b/simuleval/test/test_evaluator.py
@@ -16,8 +16,10 @@ ROOT_PATH = Path(__file__).parents[2]
 def test_score_only(root_path=ROOT_PATH):
     with tempfile.TemporaryDirectory() as tmpdirname:
         cli.sys.argv[1:] = [
-            "--agent",
-            os.path.join(root_path, "examples", "quick_start", "first_agent.py"),
+            "--user-dir", 
+            os.path.join(root_path, "examples"),
+            "--agent-class",
+            "examples.quick_start.first_agent.DummyWaitkTextAgent",
             "--source",
             os.path.join(root_path, "examples", "quick_start", "source.txt"),
             "--target",

--- a/simuleval/test/test_remote_evaluation.py
+++ b/simuleval/test/test_remote_evaluation.py
@@ -21,8 +21,10 @@ def p1(port, root_path):
         "--standalone",
         "--remote-port",
         str(port),
-        "--agent",
-        os.path.join(root_path, "examples", "quick_start", "first_agent.py"),
+        "--user-dir",
+        os.path.join(root_path, "examples"),
+        "--agent-class",
+        "examples.quick_start.first_agent.DummyWaitkTextAgent",
     ]
     cli.main()
     time.sleep(5)


### PR DESCRIPTION
Running `python -m pytest simuleval/test` previously failed due to importing multiple agents into EVALUATION_SYSTEM_LIST. Handle this scenario by allowing users to specify the agent-class. Also allow adding a --user-dir