### PR TITLE
Add Whisper Wait-K example and WER scorer

### DIFF
--- a/examples/speech_to_text/eval_whipser_waitk.sh
+++ b/examples/speech_to_text/eval_whipser_waitk.sh
@@ -1,6 +1,0 @@
-simuleval \
-    --agent whisper_waitk.py \
-    --source-segment-size 500 \
-    --waitk-lagging 3 \
-    --source source.txt --target reference/transcript.txt \
-    --output output --quality-metrics WER

--- a/examples/speech_to_text/eval_whipser_waitk.sh
+++ b/examples/speech_to_text/eval_whipser_waitk.sh
@@ -1,0 +1,6 @@
+simuleval \
+    --agent whisper_waitk.py \
+    --source-segment-size 500 \
+    --waitk-lagging 3 \
+    --source source.txt --target reference/transcript.txt \
+    --output output --quality-metrics WER

--- a/examples/speech_to_text/readme.md
+++ b/examples/speech_to_text/readme.md
@@ -40,3 +40,23 @@ The results of the evaluation should be as following. The detailed results can b
   BLEU     LAAL       AL     AP       DAL       ATD
  100.0  822.018  822.018  0.581  1061.271  2028.555
 ```
+
+### Example Streaming ASR: Whipser Wait-K model
+
+This section provide a more realistic model. [whisper_waitk.py](whisper_waitk.py) is a streaming ASR agent running [wait-k](https://aclanthology.org/P19-1289/) policy on the [Whispser](https://github.com/openai/whisper) ASR model
+
+```bash
+simuleval \
+    --agent whisper_waitk.py \
+    --source-segment-size 500 \
+    --waitk-lagging 3 \
+    --source source.txt --target reference/transcript.txt \
+    --output output --quality-metrics WER
+```
+
+The results of the evaluation should be as following. The detailed results can be found in the `output` directory.
+
+```
+WER     LAAL    AL      AP      DAL     ATD
+25.0    2353.772        2353.772        0.721   2491.04 2457.847
+```

--- a/examples/speech_to_text/readme.md
+++ b/examples/speech_to_text/readme.md
@@ -41,9 +41,9 @@ The results of the evaluation should be as following. The detailed results can b
  100.0  822.018  822.018  0.581  1061.271  2028.555
 ```
 
-### Example Streaming ASR: Whipser Wait-K model
+### Example Streaming ASR / S2T: Whipser Wait-K model
 
-This section provide a more realistic model. [whisper_waitk.py](whisper_waitk.py) is a streaming ASR agent running [wait-k](https://aclanthology.org/P19-1289/) policy on the [Whispser](https://github.com/openai/whisper) ASR model
+This section provide a more realistic model. [whisper_waitk.py](whisper_waitk.py) is a streaming ASR agent running [wait-k](https://aclanthology.org/P19-1289/) policy on the [Whisper](https://github.com/openai/whisper) ASR model
 
 ```bash
 simuleval \
@@ -60,3 +60,5 @@ The results of the evaluation should be as following. The detailed results can b
 WER     LAAL    AL      AP      DAL     ATD
 25.0    2353.772        2353.772        0.721   2491.04 2457.847
 ```
+
+This agent can also perform S2T task, by adding `--task translate`.

--- a/examples/speech_to_text/reference/transcript.txt
+++ b/examples/speech_to_text/reference/transcript.txt
@@ -1,0 +1,1 @@
+This is a synthesized audio file to test your simultaneous speech to text and to speech to speach translation system.

--- a/examples/speech_to_text/whisper_waitk.py
+++ b/examples/speech_to_text/whisper_waitk.py
@@ -52,6 +52,7 @@ class WaitkWhipser(SpeechToTextAgent):
             prefix=previous_translation,
             language=self.target_language,
             without_timestamps=True,
+            fp16=False,
         )
         audio = whisper.pad_or_trim(numpy.array(states.source).astype("float32"))
         mel = whisper.log_mel_spectrogram(audio).to(self.model.device)

--- a/examples/speech_to_text/whisper_waitk.py
+++ b/examples/speech_to_text/whisper_waitk.py
@@ -1,0 +1,65 @@
+from typing import Optional
+from simuleval.agents.states import AgentStates
+from simuleval.utils import entrypoint
+from simuleval.data.segments import SpeechSegment
+from simuleval.agents import SpeechToTextAgent
+from simuleval.agents.actions import WriteAction, ReadAction
+
+import whisper
+import numpy
+
+
+@entrypoint
+class WaitkWhipser(SpeechToTextAgent):
+    """
+    The agent generate the number of seconds from an input audio.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.waitk_lagging = args.waitk_lagging
+        self.source_segment_size = args.source_segment_size
+        self.target_language = args.target_language
+        self.continuous_write = args.continuous_write
+        self.model = whisper.load_model("tiny")
+
+    @staticmethod
+    def add_args(parser):
+        parser.add_argument("--waitk-lagging", default=1, type=int)
+        parser.add_argument("--target-language", default="en", type=str)
+        parser.add_argument("--continuous-write", default=1, type=int)
+
+    def policy(self, states: Optional[AgentStates] = None):
+        if states is None:
+            states = self.states
+
+        if states.source_sample_rate == 0:
+            # empty source, source_sample_rate not set yet
+            length_in_seconds = 0
+        else:
+            length_in_seconds = float(len(states.source)) / states.source_sample_rate
+
+        if not states.source_finished:
+            if (
+                length_in_seconds * 1000 / self.source_segment_size
+            ) < self.waitk_lagging:
+                return ReadAction()
+
+        previous_translation = " ".join(states.target)
+        options = whisper.DecodingOptions(
+            prefix=previous_translation,
+            language=self.target_language,
+            without_timestamps=True,
+        )
+        audio = whisper.pad_or_trim(numpy.array(states.source).astype("float32"))
+        mel = whisper.log_mel_spectrogram(audio).to(self.model.device)
+        output = self.model.decode(mel, options)
+        prediction = output.text.split()
+
+        if not states.source_finished and self.continuous_write > 0:
+            prediction = prediction[: self.continuous_write]
+
+        return WriteAction(
+            content=" ".join(prediction),
+            finished=states.source_finished,
+        )

--- a/examples/speech_to_text/whisper_waitk.py
+++ b/examples/speech_to_text/whisper_waitk.py
@@ -21,13 +21,15 @@ class WaitkWhipser(SpeechToTextAgent):
         self.source_segment_size = args.source_segment_size
         self.target_language = args.target_language
         self.continuous_write = args.continuous_write
-        self.model = whisper.load_model("tiny")
+        self.model_size = args.model_size
+        self.model = whisper.load_model(self.model_size)
 
     @staticmethod
     def add_args(parser):
         parser.add_argument("--waitk-lagging", default=1, type=int)
         parser.add_argument("--target-language", default="en", type=str)
         parser.add_argument("--continuous-write", default=1, type=int)
+        parser.add_argument("--model-size", default="tiny", type=str)
 
     def policy(self, states: Optional[AgentStates] = None):
         if states is None:

--- a/simuleval/evaluator/scorers/quality_scorer.py
+++ b/simuleval/evaluator/scorers/quality_scorer.py
@@ -75,8 +75,11 @@ class WERScorer(QualityScorer):
         for ins in instances.values():
             distance += self.ed.eval(ins.prediction.split(), ins.reference.split())
             ref_length += len(ins.reference.split())
+            if ref_length == 0:
+                self.logger.warning("Reference length is 0. Return WER as 0.")
+                return 0
 
-        return 100.0 * distance / ref_length if ref_length > 0 else 0
+        return 100.0 * distance / ref_length
 
     @classmethod
     def from_args(cls, args):


### PR DESCRIPTION
Add a whipser wait-k agent in the speech-to-text example. The default is whipser "tiny" model which shouldn't be a huge issue run on a laptop.

Maybe in the future, we can also consider adding it into speech-to-speech example.