### PR TITLE
Fix Workflow Issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libsndfile1
         python -m pip install --upgrade pip
         pip install flake8 pytest black


### PR DESCRIPTION
Seeing the following error in the checks in all the recent PR:
```
Run sudo apt-get install libsndfile1
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libflac8 libopus0 libvorbisenc2
Suggested packages:
  opus-tools
The following NEW packages will be installed:
  libflac8 libopus0 libsndfile1 libvorbisenc2
0 upgraded, 4 newly installed, 0 to remove and 28 not upgraded.
Need to get 593 kB of archives.
After this operation, [19](https://github.com/facebookresearch/SimulEval/actions/runs/6243790929/job/16949725174?pr=78#step:4:20)52 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libflac8 amd64 1.3.3-2ubuntu0.1
Get:3 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libopus0 amd64 1.3.1-0.1build2 [[20](https://github.com/facebookresearch/SimulEval/actions/runs/6243790929/job/16949725174?pr=78#step:4:21)3 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libvorbisenc2 amd64 1.3.7-1build2 [82.6 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libsndfile1 amd64 1.0.31-2build1 [196 kB]
Ign:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libflac8 amd64 1.3.3-2ubuntu0.1
Ign:2 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libflac8 amd64 1.3.3-2ubuntu0.1
Err:2 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libflac8 amd64 1.3.3-2ubuntu0.1
  404  Not Found [IP: 52.[25](https://github.com/facebookresearch/SimulEval/actions/runs/6243790929/job/16949725174?pr=78#step:4:26)2.75.106 80]
Fetched 482 kB in 0s (1106 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/f/flac/libflac8_1.3.3-2ubuntu0.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

This is blocking all the checks including lint, formatting and tests. 