### PR TITLE
Update setup.py sacrebleu dependency to be compatible with fairseq's

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "pytest",
         "pytest-cov",
-        "sacrebleu==2.3.1",
+        "sacrebleu>==2.3.1",
         "tornado",
         "soundfile",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "pytest",
         "pytest-cov",
-        "sacrebleu>==2.3.1",
+        "sacrebleu>=2.3.1",
         "tornado",
         "soundfile",
         "pandas",


### PR DESCRIPTION
When installing fairseq & simuleval in the same project they currently complain of conflicting dependencies, since fairseq depends on sacrebleu@master and sacrebleu just updated master from 2.3.1 to 2.3.2.

```
ERROR: Cannot install fairseq and fairseq==0.12.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    fairseq 0.12.2 depends on sacrebleu 2.3.2 (from git+https://github.com/mjpost/sacrebleu.git@master)
    simuleval 1.1.0 depends on sacrebleu==2.3.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

This should allow them to both depend on 2.3.2.