### PR TITLE
Auto register dataloader

### DIFF
--- a/simuleval/options.py
+++ b/simuleval/options.py
@@ -10,7 +10,11 @@ import sys
 import logging
 import argparse
 from typing import List, Optional
-from simuleval.data.dataloader import DATALOADER_DICT, GenericDataloader
+from simuleval.data.dataloader import (
+    DATALOADER_DICT,
+    GenericDataloader,
+    register_dataloader_class,
+)
 from simuleval.evaluator.scorers import get_scorer_class
 
 
@@ -21,6 +25,16 @@ def add_dataloader_args(
         args, _ = parser.parse_known_args()
     else:
         args, _ = parser.parse_known_args(cli_argument_list)
+
+    if args.dataloader_class:
+        dataloader_module = importlib.import_module(
+            ".".join(args.dataloader_class.split(".")[:-1])
+        )
+        dataloader_class = getattr(
+            dataloader_module, args.dataloader_class.split(".")[-1]
+        )
+        register_dataloader_class(args.dataloader, dataloader_class)
+
     dataloader_class = DATALOADER_DICT.get(args.dataloader)
     if dataloader_class is None:
         dataloader_class = GenericDataloader
@@ -168,6 +182,9 @@ def general_parser():
         help="Name of the config yaml of the system configs.",
     )
     parser.add_argument("--dataloader", default=None, help="Dataloader to use")
+    parser.add_argument(
+        "--dataloader-class", default=None, help="Dataloader class to use"
+    )
     parser.add_argument(
         "--log-level",
         type=str,


### PR DESCRIPTION
Registering a dataloader seems to happen when importing that daloader module, but if we want to use the simuleval cli for running inference directly we would want a way to register the dataloader that is  passed in as an arg. 

This PR will enable doing something like :
```
simuleval --agent seamless_communication/src/seamless_communication/agents/mma_m4t_s2t.py --agent-class seamless_communication.agents.mma_m4t_s2t.MonotonicM4TS2TSPMAgent --source-segment-size 320 --dataloader="fairseq2_s2tt" --data-file /large_experiments/seamless/ust/abinesh/data/m4tv2/dev_mtedx_filt_50-10_debug.tsv --task s2tt --device "cuda:0" --dtype fp16 --output MonotonicM4TS2TSPMAgent-debug --dataloader-class seamless_communication.agents.dataloader.SCSpeechToTextDataloader 
```