### PR TITLE
fix bug in computation aware latency

### DIFF
--- a/simuleval/evaluator/evaluator.py
+++ b/simuleval/evaluator/evaluator.py
@@ -12,6 +12,7 @@ import os
 from argparse import Namespace
 from pathlib import Path
 from typing import Dict, Generator, Optional
+from copy import deepcopy
 
 import pandas
 import yaml
@@ -283,7 +284,9 @@ class SentenceLevelEvaluator(object):
         latency_scorers = {}
         use_ref_len = not args.no_use_ref_len
         for name in args.latency_metrics:
-            latency_scorers[name] = get_scorer_class("latency", name).from_args(args)
+            latency_args=deepcopy(args)
+            latency_args.computation_aware=False
+            latency_scorers[name] = get_scorer_class("latency", name).from_args(latency_args)
             if args.computation_aware:
                 latency_scorers[name + "_CA"] = get_scorer_class("latency", name)(
                     computation_aware=True, use_ref_len=use_ref_len


### PR DESCRIPTION
Fixed a bug where non-ca latency (e.g. AL) and ca latency (e.g. AL_CA) results are consistent when using --computation-aware.