### PR TITLE
CLI improvements

### DIFF
--- a/simuleval/evaluator/evaluator.py
+++ b/simuleval/evaluator/evaluator.py
@@ -79,6 +79,7 @@ class SentenceLevelEvaluator(object):
         self.args = args
         self.output = Path(args.output) if args.output else None
         self.score_only = args.score_only
+        self.no_scoring = args.no_scoring
         self.source_segment_size = getattr(args, "source_segment_size", 1)
         self.source_type = getattr(args, "source_type", None)
         self.target_type = getattr(args, "target_type", None)
@@ -270,8 +271,9 @@ class SentenceLevelEvaluator(object):
 
         if self.output:
             self.build_instances_from_log()
-        self.dump_results()
-        self.dump_metrics()
+        if not self.no_scoring:
+            self.dump_results()
+            self.dump_metrics()
 
     @classmethod
     def from_args(cls, args):

--- a/simuleval/evaluator/instance.py
+++ b/simuleval/evaluator/instance.py
@@ -5,15 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-import time
 import math
-from typing import Dict, List, Optional, Union
+import time
+from argparse import Namespace
 from pathlib import Path
-
-from simuleval.data.segments import TextSegment, SpeechSegment, EmptySegment
+from typing import Dict, List, Optional, Union
 
 from simuleval.data.dataloader import SpeechToTextDataloader, TextToTextDataloader
-from argparse import Namespace
+from simuleval.data.segments import EmptySegment, SpeechSegment, TextSegment
 
 try:
     import soundfile

--- a/simuleval/options.py
+++ b/simuleval/options.py
@@ -207,16 +207,35 @@ def general_parser(
         choices=[x.lower() for x in logging._levelToName.values()],
         help="Log level.",
     )
-    parser.add_argument(
+    scoring_arg_group = parser.add_mutually_exclusive_group()
+    scoring_arg_group.add_argument(
         "--score-only",
         action="store_true",
         default=False,
         help="Only score the inference file.",
     )
+    scoring_arg_group.add_argument(
+        "--no-scoring",
+        action="store_true",
+        help="No scoring after inference",
+    )
     parser.add_argument(
         "--device", type=str, default="cpu", help="Device to run the model."
     )
-    parser.add_argument("--fp16", action="store_true", default=False, help="Use fp16.")
+    dtype_arg_group = parser.add_mutually_exclusive_group()
+    dtype_arg_group.add_argument(
+        "--dtype",
+        choices=["fp16", "fp32"],
+        type=str,
+        help=(
+            "Choose between half-precision (fp16) and single precision (fp32) floating point formats."
+            + " Prefer this over the fp16 flag."
+        ),
+    )
+    dtype_arg_group.add_argument(
+        "--fp16", action="store_true", default=False, help="Use fp16."
+    )
+
     return parser
 
 


### PR DESCRIPTION
- Added `--no-scoring` option to enable inference without scoring. This is mutually exclusive with `--score-only`.
- Added `--dtype` arg and made it mutually exclusive with `--fp16`.
- Moved the help menu arg to more appropriate position so that we can get the help menu for the CLI before building the pipeline. for eg:
```bash
❯ streaming_evaluate --task s2st --data-file "/large_experiments/seamless/ust/annaysun/datasets/s2ut_pt/x2t_v2/dev_fleurs_spa-eng.tsv" --audio-root-dir "/large_experiments/seamless/ust/data/audio_zips" --output "S2ST_debug" --tgt-lang eng -h
usage: streaming_evaluate [--expressive] [--user-dir USER_DIR] [--remote-eval] [--standalone] [--slurm] [--agent AGENT] [--agent-class AGENT_CLASS] [--system-dir SYSTEM_DIR] [--system-config SYSTEM_CONFIG] [--dataloader DATALOADER]
                          [--dataloader-class DATALOADER_CLASS] [--log-level {critical,error,warning,info,debug,notset}] [--score-only | --no-scoring] [--device DEVICE] [--fp16] [--quality-metrics QUALITY_METRICS [QUALITY_METRICS ...]]
                          [--latency-metrics LATENCY_METRICS [LATENCY_METRICS ...]] [--continue-unfinished] [--computation-aware] [--no-use-ref-len] [--eval-latency-unit {word,char,spm}] [--eval-latency-spm-model EVAL_LATENCY_SPM_MODEL]
                          [--remote-address REMOTE_ADDRESS] [--remote-port REMOTE_PORT] [--no-progress-bar] [--start-index START_INDEX] [--end-index END_INDEX] [--whisper-model-name WHISPER_MODEL_NAME] [--whisper-normalize-text-output]
                          [--ref-text-col-name REF_TEXT_COL_NAME] [--pred-text-col-name PRED_TEXT_COL_NAME] [--pred-audio-col-name PRED_AUDIO_COL_NAME] [--slurm-partition SLURM_PARTITION] [--slurm-job-name SLURM_JOB_NAME]
                          [--slurm-time SLURM_TIME] --data-file DATA_FILE [--audio-root-dir AUDIO_ROOT_DIR] [--ref-field REF_FIELD] [--source-segment-size SOURCE_SEGMENT_SIZE] --output OUTPUT [--no-strip-silence] [--standardize-audio]
                          [--shift-size SHIFT_SIZE] [--window-size WINDOW_SIZE] [--feature-dim FEATURE_DIM] [--denormalize] [--min-starting-wait-w2vbert MIN_STARTING_WAIT_W2VBERT] [--max-len-a MAX_LEN_A] [--max-len-b MAX_LEN_B]
                          [--max-consecutive-write MAX_CONSECUTIVE_WRITE] [--min-starting-wait MIN_STARTING_WAIT] [--no-early-stop] [--tgt-lang TGT_LANG] [--decision-threshold DECISION_THRESHOLD] [--decision-method {mean,min,median}]
                          [--p-choose-start-layer P_CHOOSE_START_LAYER] [--block-ngrams] --min-unit-chunk-size MIN_UNIT_CHUNK_SIZE [--d-factor D_FACTOR] [--vocoder-name VOCODER_NAME] [--vocoder-speaker-id VOCODER_SPEAKER_ID] [--task TASK]
                          [--unity-model-name UNITY_MODEL_NAME] [--monotonic-decoder-model-name MONOTONIC_DECODER_MODEL_NAME] [--sample-rate SAMPLE_RATE] [--dtype {fp16,fp32}] [-h]

Streaming evaluation of Seamless UnitY models

options:
  --expressive          Expressive streaming S2ST inference
  --user-dir USER_DIR   path to a python module containing custom agents
  --remote-eval         Evaluate a standalone agent
  --standalone
  --slurm               Use slurm.
  --agent AGENT         Agent file
  --agent-class AGENT_CLASS
                        The full string of class of the agent.
  --system-dir SYSTEM_DIR
                        Directory that contains everything to start the simultaneous system.
  --system-config SYSTEM_CONFIG
                        Name of the config yaml of the system configs.
  --dataloader DATALOADER
                        Dataloader to use
  --dataloader-class DATALOADER_CLASS
                        Dataloader class to use
  --log-level {critical,error,warning,info,debug,notset}
                        Log level.
  --score-only          Only score the inference file.
  --no-scoring          No scoring after inference
  --device DEVICE       Device to run the model.
  --fp16                Use fp16.
  --quality-metrics QUALITY_METRICS [QUALITY_METRICS ...]
                        Quality metrics
  --latency-metrics LATENCY_METRICS [LATENCY_METRICS ...]
                        Latency metrics
  --continue-unfinished
                        Continue the experiments in output dir.
  --computation-aware   Include computational latency.
  --no-use-ref-len      Include computational latency.
  --eval-latency-unit {word,char,spm}
                        Basic unit used for latency calculation, choose from words (detokenized) and characters.
  --eval-latency-spm-model EVAL_LATENCY_SPM_MODEL
                        Pass the spm model path if the eval_latency_unit is spm.
  --remote-address REMOTE_ADDRESS
                        Address to client backend
  --remote-port REMOTE_PORT
                        Port to client backend
  --no-progress-bar     Do not use progress bar
  --start-index START_INDEX
                        Start index for evaluation.
  --end-index END_INDEX
                        The last index for evaluation.
  --whisper-model-name WHISPER_MODEL_NAME
                        Whisper model name
  --whisper-normalize-text-output
                        Normalize text output
  --ref-text-col-name REF_TEXT_COL_NAME
                        Reference text column name
  --pred-text-col-name PRED_TEXT_COL_NAME
                        Prediction text column name
  --pred-audio-col-name PRED_AUDIO_COL_NAME
                        Prediction audio column name
  --slurm-partition SLURM_PARTITION
                        Slurm partition.
  --slurm-job-name SLURM_JOB_NAME
                        Slurm job name.
  --slurm-time SLURM_TIME
                        Slurm partition.
  --data-file DATA_FILE
                        Data file (.tsv) to be evaluated.
  --audio-root-dir AUDIO_ROOT_DIR
                        Root directory for the audio filenames in the data file.
  --ref-field REF_FIELD
                        Reference target text field to compute the BLEU score against.
  --source-segment-size SOURCE_SEGMENT_SIZE
                        Source segment size, For text the unit is # token, for speech is ms
  --output OUTPUT       Output directory. Required if using iterable dataloader.
  --no-strip-silence    Strip silence in the beginning and the end of audio.
  --standardize-audio   Standardize audio.
  --shift-size SHIFT_SIZE
                        Shift size of feature extraction window.
  --window-size WINDOW_SIZE
                        Window size of feature extraction window.
  --feature-dim FEATURE_DIM
                        Acoustic feature dimension.
  --denormalize         denormalized to 16-bit signed integers
  --min-starting-wait-w2vbert MIN_STARTING_WAIT_W2VBERT
                        Min starting wait in w2vbert
  --max-len-a MAX_LEN_A
                        Max length of predictions, a in ax + b
  --max-len-b MAX_LEN_B
                        Max length of predictions, b in ax + b
  --max-consecutive-write MAX_CONSECUTIVE_WRITE
                        Max consecutive writes.
  --min-starting-wait MIN_STARTING_WAIT
                        Minimal starting waiting source steps
  --no-early-stop
  --tgt-lang TGT_LANG
  --decision-threshold DECISION_THRESHOLD
                        The threshold to write an output, from 0 to 1. Small values give low latency.
  --decision-method {mean,min,median}
                        The method to determine the decision. Either average all attention heads, or just pick the smallest one
  --p-choose-start-layer P_CHOOSE_START_LAYER
                        Encoder layer from which p_choose should be considered for selection.
  --block-ngrams
  --min-unit-chunk-size MIN_UNIT_CHUNK_SIZE
                        Minimal units to produce every chunk
  --d-factor D_FACTOR   scaling factor for duration prediction
  --vocoder-name VOCODER_NAME
                        Vocoder name.
  --vocoder-speaker-id VOCODER_SPEAKER_ID
                        Vocoder speaker id
  --task TASK           Task type
  --unity-model-name UNITY_MODEL_NAME
                        Unity model name.
  --monotonic-decoder-model-name MONOTONIC_DECODER_MODEL_NAME
                        Monotonic decoder model name.
  --sample-rate SAMPLE_RATE
  --dtype {fp16,fp32}   Choose between half-precision (fp16) and single precision (fp32) floating point formats. Prefer this over the fp16 flag.
  -h, --help            show this help message and exit
```