### PR TITLE
FIX: user couldn't add custom cli arguments to be passed to the policy

### DIFF
--- a/simuleval/cli.py
+++ b/simuleval/cli.py
@@ -87,7 +87,7 @@ def scoring():
     options.add_evaluator_args(parser)
     options.add_scorer_args(parser)
     options.add_dataloader_args(parser)
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     evaluator = SentenceLevelEvaluator.from_args(args)
     print(evaluator.results)
 
@@ -98,7 +98,7 @@ def remote_evaluate():
     options.add_dataloader_args(parser)
     options.add_evaluator_args(parser)
     options.add_scorer_args(parser)
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     evaluator = build_remote_evaluator(args)
 
     # evaluate system

--- a/simuleval/utils/agent.py
+++ b/simuleval/utils/agent.py
@@ -142,7 +142,7 @@ def build_system_args(
         args, _ = parser.parse_known_args(cli_argument_list(config_dict))
         system = system_class.from_args(args)
 
-    args = parser.parse_args(cli_argument_list(config_dict))
+    args, _ = parser.parse_known_args(cli_argument_list(config_dict))
 
     dtype = args.dtype if args.dtype else "fp16" if args.fp16 else "fp32"
     logger.info(f"System will run on device: {args.device}. dtype: {dtype}")

--- a/simuleval/utils/slurm.py
+++ b/simuleval/utils/slurm.py
@@ -59,7 +59,7 @@ def submit_slurm_job(
     options.add_dataloader_args(parser, cli_arguments)
     system_class = get_agent_class(config_dict)
     system_class.add_args(parser)
-    args = parser.parse_args(cli_argument_list(config_dict))
+    args, _ = parser.parse_known_args(cli_argument_list(config_dict))
     args.output = os.path.abspath(args.output)
     assert mkdir_output_dir(args.output)
 


### PR DESCRIPTION
Attempting to pass custom CLI arguments to simuleval failed with "unrecognized arguments" error. With these simple fix, users can now pass their custom CLI arguments (which can be used to configure their agent). Example with two (last) arguments that will not be used by SimulEval, but can be used by parsed in the agent itself:

```bash
simuleval \
    --source SOURCES/src_100.de.txt \
    --target OFFLINE_TARGETS/tgt_100.de \
    --agent t2tt_agent_.py \
    --output ONLINE_TARGETS/out \
    --end-index 40 \
    --verbose \
    --k 5
```

